### PR TITLE
libdnf: Add include directories and LDFLAGS from librepo

### DIFF
--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -86,7 +86,8 @@ target_link_libraries(libdnf ${GLIB2_LIBRARIES})
 
 pkg_check_modules(LIBREPO REQUIRED librepo>=1.15.0)
 list(APPEND LIBDNF5_PC_REQUIRES "${LIBREPO_MODULE_NAME}")
-target_link_libraries(libdnf ${LIBREPO_LIBRARIES})
+target_include_directories(libdnf PRIVATE ${LIBREPO_INCLUDE_DIRS})
+target_link_libraries(libdnf ${LIBREPO_LDFLAGS})
 
 # SQLite3
 pkg_check_modules(SQLite3 REQUIRED sqlite3)


### PR DESCRIPTION
It's not possible to build the project when the librepo is built in a non-standard prefix, especially when no other project is build with that custom prefix.

Using the returned include directories and whole LDFLAGS fixes it.